### PR TITLE
Only display reviews data if public stream URL returns a 200 response

### DIFF
--- a/listen360-reviews-widget.php
+++ b/listen360-reviews-widget.php
@@ -41,9 +41,11 @@ function listen360_reviews_shortcode( $atts ) {
 
   $url = listen360_reviews_url( $identifier );
 
-  echo "<link rel=\"stylesheet\" type=\"text/css\" href=\"https://reviews.listen360.com/assets/listen360.css\" />\n";
-  readfile($url . "aggregaterating");
-  readfile($url . "stream?per_page=" . $atts['per_page']);
+  if ( get_headers($url, 1)[0] == 'HTTP/1.0 200 OK' ) {
+    echo "<link rel=\"stylesheet\" type=\"text/css\" href=\"https://reviews.listen360.com/assets/listen360.css\" />\n";
+    readfile($url . "aggregaterating");
+    readfile($url . "stream?per_page=" . $atts['per_page']);
+  }
 }
 
 add_shortcode('listen360_reviews', 'listen360_reviews_shortcode');


### PR DESCRIPTION
Currently if you use the plugin and your location does not have the correct disclosure level we redirect to the Listen360 homepage.

As a result, the plugin will actually display the homepage markup on the page using the Plugin.
Ex: http://testsite.lavidamassage.com/

This pull request adds logic that will only display content if the reviews location url returns a 200 status code.  
