### PR TITLE
Fix the output of the widget showing up at the top of the page

### DIFF
--- a/listen360-reviews-widget.php
+++ b/listen360-reviews-widget.php
@@ -5,7 +5,7 @@ Plugin Name: Listen360 Reviews Widget
 Plugin URI: http://developers.listen360.com/public-reviews-wordpress-widget.html
 Description: Adds a shortcode [listen360_reviews] that inserts your company's Listen360 reviews in pages or posts.
 Author: Listen360
-Version: 0.1
+Version: 0.2
 Author URI: http://www.listen360.com
 License: GPLv2
 */
@@ -121,7 +121,7 @@ echo "<h2>" . __('Listen360 Reviews Settings', 'menu-test') . "</h2>";
 
 /*
 Listen360 Reviews Widget
-Copyright (C) 2014 by Listen360
+Copyright (C) 2021 by Listen360
 
 This program is free software; you can redistribute it and/or
 modify it under the terms of the GNU General Public License

--- a/listen360-reviews-widget.php
+++ b/listen360-reviews-widget.php
@@ -11,6 +11,7 @@ License: GPLv2
 */
 
 add_option('listen360_reviews_location_url', '');
+add_option('listen360_reviews_include_stylesheet', true);
 
 function listen360_reviews_url($identifier) {
   if ($identifier == "") {
@@ -42,12 +43,13 @@ function listen360_reviews_shortcode($atts) {
 
   $response = get_headers($url . "stream", 1);
 
+  $output = '';
   if (preg_match('/200/', $response[0]) > 0) {
-    $output = "<link rel=\"stylesheet\" type=\"text/css\" href=\"https://reviews.listen360.com/assets/listen360.css\" />\n";
+    if(get_option('listen360_reviews_include_stylesheet')) {
+      $output .= "<link rel=\"stylesheet\" type=\"text/css\" href=\"https://reviews.listen360.com/assets/listen360.css\" />\n";
+    }
     $output .= file_get_contents($url . "aggregaterating");
     $output .= file_get_contents($url . "stream?per_page=" . $atts['per_page']);
-  } else {
-    $output = '';
   }
 
   return $output;
@@ -70,14 +72,17 @@ function listen360_reviews_plugin_options() {
     wp_die(__('You do not have sufficient permissions to access this page.'));
   }
 
-  $opt_val = get_option('listen360_reviews_location_url');
+  $listen360_reviews_location_url_val       = get_option('listen360_reviews_location_url');
+  $listen360_reviews_include_stylesheet_val = get_option('listen360_reviews_include_stylesheet');
 
-  if(isset($_POST[ 'listen360_reviews_form_submitted' ]) && $_POST[ 'listen360_reviews_form_submitted' ] == 'Y') {
-      // Read their posted value
-      $opt_val = $_POST[ 'listen360_reviews_location_identifier' ];
+  if(isset($_POST['listen360_reviews_form_submitted']) && $_POST['listen360_reviews_form_submitted'] == 'Y') {
+      // Read their posted values
+      $listen360_reviews_location_url_val =       $_POST['listen360_reviews_location_identifier'];
+      $listen360_reviews_include_stylesheet_val = isset($_POST['listen360_reviews_include_stylesheet']);
 
-      // Save the posted value in the database
-      update_option('listen360_reviews_location_url', $opt_val);
+      // Save the posted values in the database
+      update_option('listen360_reviews_location_url',       $listen360_reviews_location_url_val);
+      update_option('listen360_reviews_include_stylesheet', $listen360_reviews_include_stylesheet_val);
 
 ?>
 <div class="updated"><p><strong><?php _e('Listen360 Reviews settings saved.', 'menu-test'); ?></strong></p></div>
@@ -94,10 +99,16 @@ echo "<h2>" . __('Listen360 Reviews Settings', 'menu-test') . "</h2>";
 <input type="hidden" name="listen360_reviews_form_submitted" value="Y">
 
 <p><?php _e("Location Identifier:&nbsp;&nbsp;", 'menu-test'); ?>
-<input type="text" name="listen360_reviews_location_identifier" value="<?php echo $opt_val; ?>" size="40">
+<input type="text" name="listen360_reviews_location_identifier" value="<?php echo $listen360_reviews_location_url_val; ?>" size="40" />
 </p>
 <p>
-  <?php _e("This is the identifier at the end of your Listen360 Reviews page url.  For example:&nbsp;&nbsp;<strong>https://reviews.listen360.com/your-identifier-here</strong>."); ?>
+  <?php _e("&nbsp;&nbsp;This is the identifier at the end of your Listen360 Reviews page url.  For example:&nbsp;&nbsp;<strong>https://reviews.listen360.com/your-identifier-here</strong>."); ?>
+</p>
+<p><?php _e("Include Stylesheets:&nbsp;&nbsp;", 'menu-test'); ?>
+<input type="checkbox" name="listen360_reviews_include_stylesheet" <?php if($listen360_reviews_include_stylesheet_val) { echo "checked"; } ?> />
+</p>
+<p>
+  <?php _e("&nbsp;&nbsp;Uncheck this setting if you do not want to include the default Listen360 stylesheets.  In this case, you will want to make sure you setup the styles on your site correctly."); ?>
 </p>
 <p>
   <?php _e("To use the widget, simply insert the shortcode <code>[listen360_reviews]</code> on any page or post where you wish your reviews to appear.  You can reference any location's reviews by specifying an identifier in the shortcode: <code>[listen360_reviews identifier=your-location-identifier]</code>."); ?>

--- a/listen360-reviews-widget.php
+++ b/listen360-reviews-widget.php
@@ -12,82 +12,88 @@ License: GPLv2
 
 add_option('listen360_reviews_location_url', '');
 
-function listen360_reviews_url( $identifier ) {
-  if ( $identifier == "" ) {
+function listen360_reviews_url($identifier) {
+  if ($identifier == "") {
     $identifier = get_option('listen360_reviews_location_url');
   }
 
   $str = "https://reviews.listen360.com/" . $identifier;
 
-  if ( substr($str, -1) != '/' ) {
+  if (substr($str, -1) != '/') {
     $str .= "/";
   }
 
   return $str;
 }
 
-
-function listen360_reviews_shortcode( $atts ) {
-  $atts = shortcode_atts( array(
+function listen360_reviews_shortcode($atts) {
+  $atts = shortcode_atts(array(
     'per_page' => '10',
     'identifier' => ""
-  ), $atts );
+  ), $atts);
 
   $identifier = "";
 
-  if ( $atts['identifier'] != "" ) {
+  if ($atts['identifier'] != "") {
     $identifier = $atts['identifier'];
   }
 
-  $url = listen360_reviews_url( $identifier );
+  $url = listen360_reviews_url($identifier );
 
   $response = get_headers($url . "stream", 1);
-  
-  if ( preg_match('/200/', $response[0]) > 0 ) {
-    echo "<link rel=\"stylesheet\" type=\"text/css\" href=\"https://reviews.listen360.com/assets/listen360.css\" />\n";
-    readfile($url . "aggregaterating");
-    readfile($url . "stream?per_page=" . $atts['per_page']);
+
+  if (preg_match('/200/', $response[0]) > 0) {
+    $output = "<link rel=\"stylesheet\" type=\"text/css\" href=\"https://reviews.listen360.com/assets/listen360.css\" />\n";
+    $output .= file_get_contents($url . "aggregaterating");
+    $output .= file_get_contents($url . "stream?per_page=" . $atts['per_page']);
+  } else {
+    $output = '';
   }
+
+  return $output;
 }
 
-add_shortcode('listen360_reviews', 'listen360_reviews_shortcode');
+function listen360_init() {
+  add_shortcode('listen360_reviews', 'listen360_reviews_shortcode');
+}
 
-add_action( 'admin_menu', 'listen360_reviews_menu' );
+add_action('admin_menu', 'listen360_reviews_menu');
 
+add_action('init', 'listen360_init');
 
 function listen360_reviews_menu() {
-  add_options_page( 'Listen360 Reviews Options', 'Listen360', 'manage_options', 'listen360-reviews-widget', 'listen360_reviews_plugin_options' );
+  add_options_page('Listen360 Reviews Options', 'Listen360', 'manage_options', 'listen360-reviews-widget', 'listen360_reviews_plugin_options');
 }
 
 function listen360_reviews_plugin_options() {
-  if ( !current_user_can( 'manage_options' ) )  {
-    wp_die( __( 'You do not have sufficient permissions to access this page.' ) );
+  if (!current_user_can('manage_options'))  {
+    wp_die(__('You do not have sufficient permissions to access this page.'));
   }
 
-  $opt_val = get_option( 'listen360_reviews_location_url' );
+  $opt_val = get_option('listen360_reviews_location_url');
 
-  if( isset($_POST[ 'listen360_reviews_form_submitted' ]) && $_POST[ 'listen360_reviews_form_submitted' ] == 'Y' ) {
+  if(isset($_POST[ 'listen360_reviews_form_submitted' ]) && $_POST[ 'listen360_reviews_form_submitted' ] == 'Y') {
       // Read their posted value
       $opt_val = $_POST[ 'listen360_reviews_location_identifier' ];
 
       // Save the posted value in the database
-      update_option( 'listen360_reviews_location_url', $opt_val );
+      update_option('listen360_reviews_location_url', $opt_val);
 
 ?>
-<div class="updated"><p><strong><?php _e('Listen360 Reviews settings saved.', 'menu-test' ); ?></strong></p></div>
+<div class="updated"><p><strong><?php _e('Listen360 Reviews settings saved.', 'menu-test'); ?></strong></p></div>
 <?php
 
   }
 
 echo '<div class="wrap">';
-echo "<h2>" . __( 'Listen360 Reviews Settings', 'menu-test' ) . "</h2>";
+echo "<h2>" . __('Listen360 Reviews Settings', 'menu-test') . "</h2>";
 
 ?>
 
 <form name="listen360_reviews_options_form" method="post" action="">
 <input type="hidden" name="listen360_reviews_form_submitted" value="Y">
 
-<p><?php _e("Location Identifier:&nbsp;&nbsp;", 'menu-test' ); ?>
+<p><?php _e("Location Identifier:&nbsp;&nbsp;", 'menu-test'); ?>
 <input type="text" name="listen360_reviews_location_identifier" value="<?php echo $opt_val; ?>" size="40">
 </p>
 <p>
@@ -112,7 +118,6 @@ echo "<h2>" . __( 'Listen360 Reviews Settings', 'menu-test' ) . "</h2>";
 <?php
 
 }
-
 
 /*
 Listen360 Reviews Widget


### PR DESCRIPTION
The main issue was that we were just echoing the response rather than returning it from our function.  Depending on the configuration of the PHP server, sometimes this will work and the echoed string will be shoved into the response in the correct place.  Sometimes the echoed string will be the first part returned from the server with the PHP response following.  By returning the string to Wordpress as expected, I think this will now work in both cases.

Let me know if there's anything else we want to add while I'm in here.  I remember talk about making including the stylesheet be an option, etc.